### PR TITLE
Fix link to https://docs.rs/casper-types

### DIFF
--- a/source/docs/casper/dapp-dev-guide/execution-error-codes.md
+++ b/source/docs/casper/dapp-dev-guide/execution-error-codes.md
@@ -8,4 +8,4 @@ As mentioned in [Writing Rust Contracts](./writing-contracts/rust.md#using-error
 -   [mint errors](https://docs.rs/casper-types/latest/casper_types/enum.ApiError.html#variant.Mint)
 -   [custom user errors](https://docs.rs/casper-types/latest/casper_types/enum.ApiError.html#variant.User)
 
-An `ApiError` of one of these sub-types maps to an exit code with an offset defined by the sub-type. For example, an `ApiError::User(2)` maps to an exit code of `65538` (i.e. `65536 + 2`). You can find a mapping from contract exit codes to `ApiError` variants [here](https://docs.rs/casper-types/latest/casper_types/enum.ApiError.html#mappings).
+An `ApiError` of one of these sub-types maps to an exit code with an offset defined by the sub-type. For example, an `ApiError::User(2)` maps to an exit code of `65538` (i.e. `65536 + 2`). You can find a mapping from contract exit codes to `ApiError` variants [here](https://docs.rs/casper-types/latest/casper_types/enum.ApiError.html#variants).


### PR DESCRIPTION
A very small update to the link from "mappings" to "variants".